### PR TITLE
fix: 内部的に yo を正常に呼び出せない不具合を修正

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,12 +39,8 @@ switch (argv.subCommand) {
   default:
     usageExit(1)
 }
-const yeoman = spawnSync(
-  'node',
-  [require.resolve('./node_modules/yo/lib/cli.js'), `goqoo:${subGenerator}`, ...rawArgv],
-  {
-    stdio: 'inherit',
-    cwd,
-  }
-)
-process.exit(yeoman.status)
+// yo が参照するプロセスの引数とカレントディレクトリを調整
+process.argv = ['', '', `goqoo:${subGenerator}`, ...rawArgv]
+if (cwd) process.chdir(cwd)
+// ローカルインストールされた yo を呼び出す
+require('./node_modules/yo/lib/cli.js')

--- a/index.js
+++ b/index.js
@@ -39,6 +39,12 @@ switch (argv.subCommand) {
   default:
     usageExit(1)
 }
-
-const yeoman = spawnSync('yo', [`goqoo:${subGenerator}`, ...rawArgv], { stdio: 'inherit', cwd })
+const yeoman = spawnSync(
+  'node',
+  [require.resolve('./node_modules/yo/lib/cli.js'), `goqoo:${subGenerator}`, ...rawArgv],
+  {
+    stdio: 'inherit',
+    cwd,
+  }
+)
 process.exit(yeoman.status)

--- a/index.js
+++ b/index.js
@@ -2,7 +2,6 @@
 'use strict'
 
 const { parseArgumentOptions, showVersion, usageExit } = require('./lib/goqoo')
-const { spawnSync } = require('child_process')
 const path = require('path')
 const fs = require('fs-extra')
 
@@ -40,7 +39,7 @@ switch (argv.subCommand) {
     usageExit(1)
 }
 // yo が参照するプロセスの引数とカレントディレクトリを調整
-process.argv = ['', '', `goqoo:${subGenerator}`, ...rawArgv]
+process.argv = [...process.argv.slice(0, 2), `goqoo:${subGenerator}`, ...rawArgv]
 if (cwd) process.chdir(cwd)
 // ローカルインストールされた yo を呼び出す
 require('./node_modules/yo/lib/cli.js')


### PR DESCRIPTION
## 概要

- [こちらで報告された](https://note.mu/951/n/na3f113546b22) 不具合（#1 #2）は、ともに本モジュールが yeoman（yo）を呼び出す際にローカルインストールされたモジュールを明示的に参照していないことに起因する
- これを明示的にローカルインストールされたモジュールを参照するよう修正した
- また、yo をコマンドとして呼び出す方法からモジュールとしてインクルードするよう修正した

fixes #1, fixes #2
