### PR TITLE
fix: 不要なfibersオプション指定を削除

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "goqoo",
-  "version": "1.3.0-beta013",
+  "version": "1.3.0-beta014",
   "description": "Goqoo on kintone",
   "main": "./dist/lib",
   "bin": {

--- a/src/bundler/webpack.config.react.js
+++ b/src/bundler/webpack.config.react.js
@@ -57,7 +57,6 @@ module.exports = (env, argv) => {
               loader: require.resolve('sass-loader'),
               options: {
                 implementation: require.resolve('sass'),
-                fiber: require.resolve('fibers'),
               },
             },
           ],

--- a/src/bundler/webpack.config.vue.js
+++ b/src/bundler/webpack.config.vue.js
@@ -63,7 +63,6 @@ module.exports = (env, argv) => {
               loader: require.resolve('sass-loader'),
               options: {
                 implementation: require.resolve('sass'),
-                fiber: require.resolve('fibers'),
               },
             },
           ],


### PR DESCRIPTION
- [こちらのPR](https://github.com/goqoo-on-kintone/goqoo/pull/60/files)でwebpack.config.jsのsass-loader設定から不要なfibers指定を削除したのですが、react/vue用の設定の方では残ってしまっていたため、そちらも削除する修正になります。